### PR TITLE
Update iron scavenging by detritus

### DIFF
--- a/doc/manual_references.bib
+++ b/doc/manual_references.bib
@@ -1747,6 +1747,16 @@ DOI = {10.5194/gmd-6-1367-2013}
   doi = {10.1029/2003GB002061}
 }
 
+@Article{parekh:2005,
+  author = {Parekh, P. and Follows, M. J. and Boyle, E. A.},
+  title = {Decoupling of iron and phosphate in the global ocean},
+  journal = {Global Biogeochemical Cycles},
+  year = {2005},
+  volume = {19},
+  pages = {},
+  doi = {10.1029/2004GB002280}
+}
+
 @Article{parkinson:79,
   author =	 {Parkinson, C. L. and W. M. Washington},
   title =	 {A Large-Scale Numerical Model of Sea Ice},
@@ -1864,6 +1874,16 @@ year = {1982}
   year =	 2020,
   pages =	 {1--24},
   doi =		 {10.5194/tc-2020-153}
+}
+
+@Article{rios:1998,
+  author       = {Ríos, A. F. and Fraga, F. and Pérez, F. F. and Figueiras, F. G.},
+  title        = {Chemical composition of phytoplankton and {Particulate} {Organic} {Matter} in the {Ría} de {Vigo} ({NW} {Spain})},
+  journal      = {Sciencia Marina},
+  volume       = {6 2},
+  number       = {3},
+  year         = {1998},
+  pages        = {257--271},
 }
 
 @Article{roach:15,

--- a/doc/phys_pkgs/darwin.rst
+++ b/doc/phys_pkgs/darwin.rst
@@ -362,13 +362,15 @@ General parameters are set in namelist :varlink:`DARWIN_PARAMS`:
    :varlink:`uptakeTempAe`           & 0.0                   & 1/K                              & temperature coefficient for uptake (TEMP_VERSION 4)
    :varlink:`alpfe`                  & 0.04                  &                                  & solubility of Fe dust
    :varlink:`scav`                   & 0.4/year              & 1/s                              & fixed iron scavenging rate
+   :varlink:`scav_tau`               & 0.2                   &                                  & factor for converting Th scavenging rates to iron ones
+   :varlink:`scav_inter`             & 0.079 / day           & L\ :sup:`e` mg\ :sup:`-e` s\ :sup:`-1` & intercept of scavenging power law (e=e\ :sub:`scav`)
+   :varlink:`scav_exp`               & 0.58                  &                                  & exponent of scavenging power law
+   :varlink:`scav_POC_wgt`           & 0.02173               & g/mmol |nbsp| C                  & weight POC contributes to POM
+   :varlink:`scav_POSi_wgt`          & 0.069                 & g/mmol |nbsp| Si                 & weight POSi contributes to POM
+   :varlink:`scav_PIC_wgt`           & 0.100                 & g/mmol |nbsp| C                  & weight PIC contributes to POM
    :varlink:`ligand_tot`             & 1D-3                  & mol/m\ :sup:`3`                  & total ligand concentration
    :varlink:`ligand_stab`            & 2D5                   & m\ :sup:`3`/mol                  & ligand stability rate ratio
    :varlink:`freefemax`              & 0.4D-3                & mol/m\ :sup:`3`                  & max concentration of free iron
-   :varlink:`scav_rat`               & 0.005 / day           & 1/s                              & rate of POM-based iron scavenging
-   :varlink:`scav_inter`             & 0.079                 &                                  & intercept of scavenging power law
-   :varlink:`scav_exp`               & 0.58                  &                                  & exponent of scavenging power law
-   :varlink:`scav_R_POPPOC`          & 1.1321D-4             & mmol P / mmol C                  & POP\:POC ratio for :varlink:`DARWIN_PART_SCAV_POP`
    :varlink:`depthfesed`             & -1.0                  & m                                & depth above which to add sediment source (was -1000)
    :varlink:`fesedflux`              & 1D-3 / day            & mmol Fe /m\ :sup:`2`/s           & fixed iron flux from sediment
    :varlink:`fesedflux_pcm`          & 0.68D-3               & mmol Fe / mmol C                 & iron input per POC sinking into bottom for :varlink:`DARWIN_IRON_SED_SOURCE_VARIABLE`

--- a/doc/phys_pkgs/darwin_iron.rst
+++ b/doc/phys_pkgs/darwin_iron.rst
@@ -88,21 +88,42 @@ The scavenging rate for free iron is
 .. math::
 
    r_{{\text{scav}}}= \begin{cases}
-       r_{{\text{scav}}}I_{{\text{scav}}}\op{POC}^{e_{{\text{scav}}}}
-       & \text{for POM-based scavenging,} \\
        \op{scav}
-       & \text{for constant scavenging.}
+       & \text{for fixed-rate scavenging,} \\
+       \tau_{{\text{scav}}}I_{{\text{scav}}}\op{POM}^{e_{{\text{scav}}}}
+       & \text{for particle-based scavenging.}
        \end{cases}
 
-To select POM-based scavenging, #define :varlink:`DARWIN_PART_SCAV`.
-If :varlink:`DARWIN_PART_SCAV_POP` is defined, :math:`\op{POC}` is
-replaced by :math:`\op{POP}\!/R^{\op{POP}:\op{POC}}_{{\text{scav}}}`.
+To select particle-based scavenging following Parekh et al. (2005)
+:cite:`parekh:2005`, define :varlink:`DARWIN_PART_SCAV`.  POM is the
+concentration of particulate organic matter in units of mg/L.  It is
+parameterized in terms of POC, POSi and PIC,
 
-The concentration of free iron is determined following
-Parekh et al. (2004) :cite:`parekh:2004` and
-Dutkiewicz et al. (2005) :cite:`dutkiewicz:2005`.  Free dissolved iron,
-Fe', is assumed to be in equilibrium with dissolved iron bound
-to ligands, FeL,
+.. math::
+
+   \op{POM} = w^{\text{scav}}_{\text{POC}} \op{POC}
+            + w^{\text{scav}}_{\text{POSi}} \op{POSi}
+            + w^{\text{scav}}_{\text{PIC}} \op{PIC}
+   \;.
+
+The value for :math:`w^{\text{scav}}_{\text{POC}}` is taken from Rios et al.
+(1998) :cite:`rios:1998` as the weight of as detritus without opal per mol of
+carbon.  :math:`w^{\text{scav}}_{\text{POSi}}` and
+:math:`w^{\text{scav}}_{\text{PIC}}` are just the molecular weights of opal
+(per mol Si) and calcium carbonate, see
+:numref:`tab_phys_pkgs_darwin_iron_params`.
+
+The old (and deprecated) formulation of scavenging in terms of POP can be
+recovered by defining :varlink:`DARWIN_PART_SCAV_POP`, in which case
+:math:`\op{POM}` is replaced by
+:math:`\op{POP}\!/R^{\op{POP}:\op{POC}}_{{\text{scav}}}`.  Parameter names and
+defaults are different in this case, see
+:numref:`tab_phys_pkgs_darwin_scav_pop`.
+
+The concentration of free iron, Fe', is determined following Parekh et al.
+(2004) :cite:`parekh:2004` and Dutkiewicz et al. (2005)
+:cite:`dutkiewicz:2005`.  Free dissolved iron is assumed to be in equilibrium
+with dissolved iron bound to ligands, FeL,
 
 .. math:: \op{Fe}' + L' \rightleftharpoons \op{FeL}
 
@@ -133,6 +154,7 @@ and after each biogeochemical subtimestep.
    :delim: &
    :widths: auto
    :header: Parameter, Symbol, Default, Units, Description
+   :name: tab_phys_pkgs_darwin_iron_params
 
    :varlink:`alpfe`         & :math:`\alpha_{\op{Fe}}`             & 0.04        &                        & solubility of Fe dust
    :varlink:`depthfesed`    & :math:`d_{\op{sed}}`                 & -1.0        & m                      & depth above which to add sediment source
@@ -144,10 +166,24 @@ and after each biogeochemical subtimestep.
    :varlink:`solFeVent`     & :math:`\alpha_{\op{Fe}}^{\op{vents}}` & 0.002      &                        & solubility of iron from hydrothermal vents
    :varlink:`R_FeHe3_vent`  & :math:`R^{\op{Fe:^3He}}_{\op{vents}}` & 4.5E8      & mol Fe / mol :sup:`3`\ He & Fe:\ :sup:`3`\ He ratio for hydrothermal vents
    :varlink:`scav`          & scav                                 & 0.4/year    & 1/s                    & fixed iron scavenging rate
-   :varlink:`scav_rat`      & :math:`r_{\op{scav}}`                & 0.005 / day & 1/s                    & rate of POM-based iron scavenging
-   :varlink:`scav_inter`    & :math:`I_{\op{scav}}`                & 0.079       &                        & intercept of scavenging power law
+   :varlink:`scav_tau`      & :math:`\tau_{\op{scav}}`             & 0.2         &                        & factor for converting Th scavenging rates to iron ones
+   :varlink:`scav_inter`    & :math:`I_{\op{scav}}`                & 0.079 / day & L\ :sup:`e` mg\ :sup:`-e` s\ :sup:`-1` & intercept of scavenging power law (e=e\ :sub:`scav`)
    :varlink:`scav_exp`      & :math:`e_{\op{scav}}`                & 0.58        &                        & exponent of scavenging power law
-   :varlink:`scav_R_POPPOC` & :math:`R^{\op{POP:POC}}_{\op{scav}}` & 1.1321E-4   & mmol P / mmol C        & POP\:POC ratio for :varlink:`DARWIN_PART_SCAV_POP`
+   :varlink:`scav_POC_wgt`  & :math:`w^{\op{scav}}_{\op{POC}}`     & 0.02173     & g/mmol |nbsp| C        & weight POC contributes to POM
+   :varlink:`scav_POSi_wgt` & :math:`w^{\op{scav}}_{\op{POSi}}`    & 0.069       & g/mmol |nbsp| Si       & weight POSi contributes to POM
+   :varlink:`scav_PIC_wgt`  & :math:`w^{\op{scav}}_{\op{PIC}}`     & 0.100       & g/mmol |nbsp| C        & weight PIC contributes to POM
    :varlink:`ligand_tot`    & :math:`L_{\op{T}}`                   & 1E-3        & mmol/m\ :sup:`3`       & total ligand concentration
-   :varlink:`ligand_stab`   & :math:`\beta_{\op{stab}}`            & .2E6        & m\ :sup:`3`/mmol       & ligand stability rate ratio
+   :varlink:`ligand_stab`   & :math:`\beta_{\op{stab}}`            & 0.2E6       & m\ :sup:`3`/mmol       & ligand stability rate ratio
    :varlink:`freefemax`     & :math:`\op{Fe}'_{\op{max}}`          & 0.4E-3      & mmol/m\ :sup:`3`       & max concentration of free iron
+
+
+.. csv-table:: Iron parameters for :varlink:`DARWIN_PART_SCAV_POP`
+   :delim: &
+   :widths: auto
+   :header: Parameter, Symbol, Default, Units, Description
+   :name: tab_phys_pkgs_darwin_scav_pop
+
+   :varlink:`scav_rat`      & :math:`\tau_{\op{scav}}`             & 0.005 / day & 1/s                       & rate factor
+   :varlink:`scav_inter`    & :math:`I_{\op{scav}}`                & 0.079       & L\ :sup:`e` mg\ :sup:`-e` & intercept of scavenging power law (e=e\ :sub:`scav`)
+   :varlink:`scav_exp`      & :math:`e_{\op{scav}}`                & 0.58        &                           & exponent of scavenging power law
+   :varlink:`scav_R_POPPOC` & :math:`R^{\op{POP:POC}}_{\op{scav}}` & 1.1321E-4   & mmol |nbsp| P / g         & POP\:POC ratio

--- a/pkg/darwin/darwin_diagnostics_init.F
+++ b/pkg/darwin/darwin_diagnostics_init.F
@@ -541,6 +541,13 @@ C-      use units & names from data.ptracers :
       CALL DIAGNOSTICS_ADDTOLIST( diagNum,
      I           diagName, diagCode, diagUnits, diagTitle, 0, myThid )
 
+      WRITE(diagName,'(A)')'scavRate'
+      WRITE(diagTitle,'(A)')'Iron scavenging rate'
+      diagUnits = '1/s             '
+      diagCode  = 'SMRP    MR      '
+      CALL DIAGNOSTICS_ADDTOLIST( diagNum,
+     I           diagName, diagCode, diagUnits, diagTitle, 0, myThid )
+
       WRITE(diagName,'(A)')'sedFe'
       WRITE(diagTitle,'(A)')'Iron input from sediment'
       diagUnits = 'mmol Fe/m3/s    '

--- a/pkg/darwin/darwin_diagnostics_init.F
+++ b/pkg/darwin/darwin_diagnostics_init.F
@@ -534,6 +534,13 @@ C-      use units & names from data.ptracers :
       CALL DIAGNOSTICS_ADDTOLIST( diagNum,
      I           diagName, diagCode, diagUnits, diagTitle, 0, myThid )
 
+      WRITE(diagName,'(A)')'scvLosFe'
+      WRITE(diagTitle,'(A)')'Iron loss from scavenging'
+      diagUnits = 'mmol Fe/m3/s    '
+      diagCode  = 'SMRP    MR      '
+      CALL DIAGNOSTICS_ADDTOLIST( diagNum,
+     I           diagName, diagCode, diagUnits, diagTitle, 0, myThid )
+
       WRITE(diagName,'(A)')'sedFe'
       WRITE(diagTitle,'(A)')'Iron input from sediment'
       diagUnits = 'mmol Fe/m3/s    '

--- a/pkg/darwin/darwin_forcing.F
+++ b/pkg/darwin/darwin_forcing.F
@@ -93,6 +93,7 @@ C  k                    :: vertical level
       _RL freeFe(1-OLx:sNx+OLx, 1-OLy:sNy+OLy, Nr)
       _RL sedFlxFe(1-OLx:sNx+OLx, 1-OLy:sNy+OLy)
       _RL tmp3d(1-OLx:sNx+OLx, 1-OLy:sNy+OLy, Nr)
+      _RL scavRate(1-OLx:sNx+OLx, 1-OLy:sNy+OLy, Nr)
       _RL scavLoss(1-OLx:sNx+OLx, 1-OLy:sNy+OLy, Nr)
       _RL scv,scav_pom
       _RL flx, POCl
@@ -391,6 +392,7 @@ C       compute POM in mg/L
 #else
         scv = scav
 #endif
+        scavRate(i,j,k) = scv
         scavLoss(i,j,k) = scv*MAX(0 _d 0, freefe(i,j,k))
         gPtr(i,j,k,iFeT) = gPtr(i,j,k,iFeT) - scavLoss(i,j,k)
 #ifdef DARWIN_ALLOW_CONS
@@ -895,6 +897,7 @@ C      diags(iCons*) for convenience
        ENDDO
 #endif
 #endif
+       CALL DIAGNOSTICS_FILL(scavRate,'scavRate',0,Nr,2,bi,bj,myThid)
        CALL DIAGNOSTICS_FILL(scavLoss,'scvLosFe',0,Nr,2,bi,bj,myThid)
        CALL DIAGNOSTICS_FILL(sedFe,   'sedFe   ',0,Nr,1,bi,bj,myThid)
        CALL DIAGNOSTICS_FILL(sedFlxFe,'sedFlxFe',0,1,2,bi,bj,myThid)

--- a/pkg/darwin/darwin_forcing.F
+++ b/pkg/darwin/darwin_forcing.F
@@ -93,6 +93,7 @@ C  k                    :: vertical level
       _RL freeFe(1-OLx:sNx+OLx, 1-OLy:sNy+OLy, Nr)
       _RL sedFlxFe(1-OLx:sNx+OLx, 1-OLy:sNy+OLy)
       _RL tmp3d(1-OLx:sNx+OLx, 1-OLy:sNy+OLy, Nr)
+      _RL scavLoss(1-OLx:sNx+OLx, 1-OLy:sNy+OLy, Nr)
       _RL scv,scav_pom
       _RL flx, POCl
       _RL ptr(nDarwin), gtr(nDarwin), PARl(nlam)
@@ -390,11 +391,11 @@ C       compute POM in mg/L
 #else
         scv = scav
 #endif
-        gPtr(i,j,k,iFeT) = gPtr(i,j,k,iFeT) -
-     &                     scv*MAX(0 _d 0, freefe(i,j,k))
+        scavLoss(i,j,k) = scv*MAX(0 _d 0, freefe(i,j,k))
+        gPtr(i,j,k,iFeT) = gPtr(i,j,k,iFeT) - scavLoss(i,j,k)
 #ifdef DARWIN_ALLOW_CONS
         DARWIN_partScav(i,j,k,bi,bj) = DARWIN_partScav(i,j,k,bi,bj)
-     &                    + dTsub(k)*scv*MAX(0 _d 0, freefe(i,j,k))
+     &                               + dTsub(k)*scavLoss(i,j,k)
 #endif
       ENDDO
       ENDDO
@@ -894,6 +895,7 @@ C      diags(iCons*) for convenience
        ENDDO
 #endif
 #endif
+       CALL DIAGNOSTICS_FILL(scavLoss,'scvLosFe',0,Nr,2,bi,bj,myThid)
        CALL DIAGNOSTICS_FILL(sedFe,   'sedFe   ',0,Nr,1,bi,bj,myThid)
        CALL DIAGNOSTICS_FILL(sedFlxFe,'sedFlxFe',0,1,2,bi,bj,myThid)
        IF (DIAGNOSTICS_IS_ON('sfcSolFe', myThid)) THEN


### PR DESCRIPTION
## What changes does this PR introduce?

Update formulation of iron scavening in terms of particles (#define DARWIN_PART_SCAV).

## What is the current behaviour? 

Iron scavenging is parameterized in terms of POC only and the conversion to particle weight is wrong.

## What is the new behaviour 

Scavenging is parameterized in terms of POC, POSi and PIC.  Reasonable conversion factors are provided.

## Does this PR introduce a breaking change? 

Yes.  In order to recover the previous formulation, parameters need to be changed from their defaults.

## Other Information

Docs are [here](https://darwin3.readthedocs.io/en/scavenging/phys_pkgs/darwin_iron.html#scavenging).